### PR TITLE
Add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ All secrets are optional; in that case, scraping from these
 websites will not function.
 
 - `JDANKS_PORT` · Listen port. Defaults to `80`.
-
+- `JDANKS_SSL_PORT` · Listen port for HTTPS. Defaults to `443`.
+- `JDANKS_SSL_PRIVKEY` · Location of private key. Defaults to `/etc/certs/api.jdanks.army/privkey.pem`.
+- `JDANKS_SSL_CERT` · Listen of certificate. Defaults to `/etc/certs/api.jdanks.army/fullchain.pem`.
  - `TROVO_CLIENT_ID` · for Trovo support.
  - `TWITCH_CLIENT_ID` `TWITCH_CLIENT_SECRET` · for Twitch support.
 

--- a/index.js
+++ b/index.js
@@ -90,10 +90,9 @@ httpServer.listen(port, async () => {
 
 // Try setting up an https server
 try {
-    const httpsServer = https.createServer({
-        key: fs.readFileSync('/etc/certs/api.jdanks.army/privkey.pem'),
-        cert: fs.readFileSync('/etc/certs/api.jdanks.army/fullchain.pem'),
-    }, app);
+    const key = process.env.JDANKS_SSL_PRIVKEY || '/etc/certs/api.jdanks.army/privkey.pem';
+    const cert = process.env.JDANKS_SSL_CERT || '/etc/certs/api.jdanks.army/fullchain.pem';
+    const httpsServer = https.createServer({ key, cert }, app);
     httpsServer.listen(443, () => {
         console.log(`jdanks.armyd/TLS listening to 0.0.0.0:${sslPort}`);
     });

--- a/index.js
+++ b/index.js
@@ -3,204 +3,12 @@ const express = require('express')
 const cors = require('cors');
 const assert = require("assert");
 
+const scrapers = require("./scrapers");
+
 const port = process.env.JDANKS_PORT || 80;
 const app = express()
 
 const idToData = new Map();
-
-async function youtube(id) {
-    const {data} = await axios.get(`https://youtube.com/channel/${id}`);
-
-    const avatar = data.match(/channelMetadataRenderer.*?avatar.*?thumbnails.*?url".*?"(.*?)"/s)[1];
-    const name = data.match(/channelMetadataRenderer.*?title".*?"(.*?)"/s)[1];
-
-    const {data: livedata} = await axios.get(`https://youtube.com/channel/${id}/live`);
-    let live, title;
-    try {
-        title = livedata.match(/videoPrimaryInfoRenderer".*?"title".*?"runs".*?"text".*?"(.*?)"/s)[1];
-        live = livedata.match(/playabilityStatus.*?status".*?"(.*?)"/s)[1] !== "LIVE_STREAM_OFFLINE";
-    } catch (e) {
-        live = false;
-    }
-
-    let r = {
-        avatar,
-        name,
-        live,
-        id,
-        platform: 'youtube',
-    }
-
-    if (live) {
-        r.title = title;
-        let viewers = livedata.match(/videoPrimaryInfoRenderer".*?"viewCount".*?"runs".*?"text".*?"(.*?)"/s)[1]?.split(' ')[0];
-        r.viewers = Number(viewers.replace(/[.,]/g, ""));
-    }
-
-    return r;
-}
-
-async function dlive(id) {
-    const { data } = await axios.post('https://graphigo.prd.dlive.tv/',
-        `{"query":"query{userByDisplayName(displayname: \\"${id}\\") {livestream{ view title } avatar}}"}`);
-
-    const response = data.data.userByDisplayName;
-    const live = !!response.livestream;
-
-    let r = {
-        platform: "dlive",
-        id, name: id,
-        avatar: response.avatar,
-        live,
-    }
-
-    if(live) {
-        r.viewers = response.livestream.view;
-        r.title = response.livestream.title;
-    }
-
-    return r;
-}
-
-async function bitwave(id) {
-    const {data: _data} = await axios.get(`https://api.bitwave.tv/v1/channels/${id}`);
-    if(!_data?.success) return {};
-    const data = _data.data;
-    return {
-        live: data.live,
-        name: data.name,
-        avatar: data.avatar,
-        id,
-        platform: "bitwave",
-        viewers: data.viewCount,
-        title: data.title,
-    };
-}
-
-async function robotstreamer(id, name) {
-    const {data: _data} = await axios.get(`http://api.robotstreamer.com:8080/v1/get_robot/${id}`);
-    const data = _data[0];
-    const live = data.status === "online";
-    const title = data.robot_name;
-    const viewers = data.viewers;
-    return {
-        live, name, id,
-        platform: "robotstreamer",
-        title, viewers
-    }
-}
-
-const trovo_id_memoization = new Map();
-async function trovo(username) {
-    const token = process.env.TROVO_CLIENT_ID;
-
-    assert( !!token );
-
-    if( !trovo_id_memoization.has(username) ) {
-        const {data} = await axios.post(
-            'https://open-api.trovo.live/openplatform/getusers',
-            {user: [username]},
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json',
-                    'Client-ID': token,
-                }
-            }
-        );
-        trovo_id_memoization.set(username, data.users[0].channel_id );
-    }
-
-    assert(trovo_id_memoization.has(username));
-
-    const {data} = await axios.post(
-        'https://open-api.trovo.live/openplatform/channels/id',
-        {channel_id: trovo_id_memoization.get(username)},
-        {
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-                'Client-ID': token,
-            }
-        }
-    );
-
-    return {
-        live: data.is_live,
-        title: data.live_title,
-        viewers: data.current_viewers,
-        id: username, platform: "trovo",
-        name: username,
-        avatar: data.profile_pic,
-    }
-}
-
-const twitch_avatars = new Map();
-let twitch_access_token;
-
-async function twitch_init() {
-    const {data} = await axios.post(
-        `https://id.twitch.tv/oauth2/token`
-        + `?client_id=${process.env.TWITCH_CLIENT_ID}`
-        + `&client_secret=${process.env.TWITCH_CLIENT_SECRET}`
-        + `&grant_type=client_credentials`
-    );
-    twitch_access_token = data;
-
-    setInterval(async () => {
-        twitch_access_token = (await axios.post(
-            `https://id.twitch.tv/oauth2/token`
-            + `?client_id=${process.env.TWITCH_CLIENT_ID}`
-            + `&client_secret=${process.env.TWITCH_CLIENT_SECRET}`
-            + `&grant_type=client_credentials`
-        )).data;
-    }, twitch_access_token.expires_in);
-}
-
-async function twitch(username) {
-    const access_token = (await twitch_access_token).access_token;
-
-    // Update avatar every fifth scrape of the same username
-    // or; update every avatars every 25 minutes
-    if( !twitch_avatars.has(username) || twitch_avatars.get(username)[1] === 5 ) {
-        const {data: user_data} = await axios.get(`https://api.twitch.tv/helix/users?login=${username}`, {
-            headers: {
-                'Client-Id': process.env.TWITCH_CLIENT_ID,
-                'Authorization': `Bearer ${access_token}`
-            }
-        });
-        twitch_avatars.set(username, [user_data.data[0].profile_image_url, 5]);
-    } else {
-        twitch_avatars.get(username)[1]--;
-    }
-
-    const {data: _data} = await axios.get(`https://api.twitch.tv/helix/streams?user_login=${username}`, {
-        headers: {
-            'Client-Id': process.env.TWITCH_CLIENT_ID,
-            'Authorization': `Bearer ${access_token}`
-        }
-    });
-    const stream_data = _data.data[0];
-
-    return {
-        live: stream_data.type === "live",
-        name: username,
-        id: username,
-        avatar: twitch_avatars.get(username)[0],
-        platform: "twitch",
-        title: stream_data.title,
-        viewers: stream_data.viewer_count
-    };
-}
-
-const scrapers = new Map([
-    ["youtube", youtube],
-    ["dlive", dlive],
-    ["bitwave", bitwave],
-    ["robotstreamer", robotstreamer],
-    ["trovo", trovo],
-    ["twitch", twitch],
-]);
 
 const rateLimit = require("express-rate-limit");
 const limiter = rateLimit({
@@ -239,14 +47,12 @@ async function scrape(platform, id, name) {
 const loadPeople = (async (people) => {
     console.info("Populating scrape data...");
 
-    await twitch_init();
-
     // multithread all initial scrapes, wait for them all to finish
     await Promise.all(people.map(async (person, i) => {
         const platform = person[0];
         const id = person[1];
 
-        scrape(platform, id, person[2]);
+        await scrape(platform, id, person[2]);
         console.info(`Scraped ${id}!`);
 
         setTimeout(() => {

--- a/people.json
+++ b/people.json
@@ -52,15 +52,15 @@
   ["robotstreamer", "3842", "JIA"],
   ["bitwave", "Cyberdemon531", "beans"],
   ["bitwave", "JDANKS.ARMY", "beans"],
-  
+
   ["youtube", "UCAr_VuxFMsgDULuunJjlJkA", "leopirate"],
   ["bitwave", "leopirate"],
-  
+
   ["robotstreamer", "100", "Pippy (Rick)"],
   ["robotstreamer", "106", "TrumpBot (Rick)"],
   ["robotstreamer", "546", "AssBlaster2 (Rick)"],
-  
+
   ["robotstreamer", "3737", "duhsten"],
-  
+
   ["robotstreamer", "108", "JennyBot2 (E7)"]
 ]

--- a/scrapers.js
+++ b/scrapers.js
@@ -1,5 +1,11 @@
 const fs = require("fs");
-const files = fs.readdirSync('./scrapers');
-const jsFiles = files.filter(f => f.endsWith('.js'));
-const scrapers = jsFiles.map(x => require('./scrapers/' + x));
+const scrapers = fs
+    .readdirSync('./scrapers')
+    .filter(f => f.endsWith('.js'))
+    .map(x => require('./scrapers/' + x))
+    .map(x => [x[0], (...args) => {
+        let r = x[1](...args);
+        r.platform = x[0];
+        return r;
+    }]);
 module.exports = new Map(scrapers);

--- a/scrapers.js
+++ b/scrapers.js
@@ -1,0 +1,5 @@
+const fs = require("fs");
+const files = fs.readdirSync('./scrapers');
+const jsFiles = files.filter(f => f.endsWith('.js'));
+const scrapers = jsFiles.map(x => require('./scrapers/' + x));
+module.exports = new Map(scrapers);

--- a/scrapers.js
+++ b/scrapers.js
@@ -3,9 +3,13 @@ const scrapers = fs
     .readdirSync('./scrapers')
     .filter(f => f.endsWith('.js'))
     .map(x => require('./scrapers/' + x))
-    .map(x => [x[0], (...args) => {
-        let r = x[1](...args);
+    .map(x => [x[0], async (...args) => {
+        let r = await x[1](...args);
         r.platform = x[0];
+        if(!r.live) {
+            delete r.viewers;
+            delete r.title;
+        }
         return r;
     }]);
 module.exports = new Map(scrapers);

--- a/scrapers/bitwave.js
+++ b/scrapers/bitwave.js
@@ -1,0 +1,16 @@
+const axios = require("axios");
+
+const platform = "bitwave";
+module.exports = [platform, async function (id) {
+    const {data: _data} = await axios.get(`https://api.bitwave.tv/v1/channels/${id}`);
+    if (!_data?.success) return {};
+    const data = _data.data;
+    return {
+        live: data.live,
+        name: data.name,
+        avatar: data.avatar,
+        id, platform,
+        viewers: data.viewCount,
+        title: data.title,
+    };
+}];

--- a/scrapers/dlive.js
+++ b/scrapers/dlive.js
@@ -1,0 +1,18 @@
+const axios = require("axios");
+
+const platform = "dlive";
+module.exports = [platform, async function (id) {
+    const {data} = await axios.post('https://graphigo.prd.dlive.tv/',
+        `{"query":"query{userByDisplayName(displayname: \\"${id}\\") {livestream{ view title } avatar}}"}`);
+
+    const response = data.data.userByDisplayName;
+    const live = !!response.livestream;
+
+    return {
+        platform, id, name: id,
+        avatar: response.avatar,
+        live,
+        viewers: response.livestream.view,
+        title: response.livestream.title,
+    };
+}];

--- a/scrapers/dlive.js
+++ b/scrapers/dlive.js
@@ -1,7 +1,6 @@
 const axios = require("axios");
 
-const platform = "dlive";
-module.exports = [platform, async function (id) {
+module.exports = ["dlive", async function (id) {
     const {data} = await axios.post('https://graphigo.prd.dlive.tv/',
         `{"query":"query{userByDisplayName(displayname: \\"${id}\\") {livestream{ view title } avatar}}"}`);
 
@@ -9,7 +8,7 @@ module.exports = [platform, async function (id) {
     const live = !!response.livestream;
 
     return {
-        platform, id, name: id,
+        id, name: id,
         avatar: response.avatar,
         live,
         viewers: response.livestream.view,

--- a/scrapers/dlive.js
+++ b/scrapers/dlive.js
@@ -1,17 +1,16 @@
 const axios = require("axios");
 
-module.exports = ["dlive", async function (id) {
+module.exports = ["dlive", async function (name) {
     const {data} = await axios.post('https://graphigo.prd.dlive.tv/',
-        `{"query":"query{userByDisplayName(displayname: \\"${id}\\") {livestream{ view title } avatar}}"}`);
+        `{"query":"query{userByDisplayName(displayname: \\"${name}\\") {livestream{ view title } avatar}}"}`);
 
     const response = data.data.userByDisplayName;
     const live = !!response.livestream;
 
     return {
-        id, name: id,
         avatar: response.avatar,
-        live,
-        viewers: response.livestream.view,
-        title: response.livestream.title,
+        live, name,
+        viewers: response.livestream?.view,
+        title: response.livestream?.title,
     };
 }];

--- a/scrapers/robotstreamer.js
+++ b/scrapers/robotstreamer.js
@@ -9,7 +9,7 @@ module.exports = ["robotstreamer", async function (id, name) {
     const viewers = data.viewers;
 
     return {
-        live, name, id,
+        live, name,
         title, viewers
     }
 }];

--- a/scrapers/robotstreamer.js
+++ b/scrapers/robotstreamer.js
@@ -1,7 +1,6 @@
 const axios = require("axios");
 
-const platform = "robotstreamer";
-module.exports = [platform, async function (id, name) {
+module.exports = ["robotstreamer", async function (id, name) {
     const {data: _data} = await axios.get(`http://api.robotstreamer.com:8080/v1/get_robot/${id}`);
     const data = _data[0];
 
@@ -11,7 +10,6 @@ module.exports = [platform, async function (id, name) {
 
     return {
         live, name, id,
-        platform, title,
-        viewers
+        title, viewers
     }
 }];

--- a/scrapers/robotstreamer.js
+++ b/scrapers/robotstreamer.js
@@ -1,0 +1,17 @@
+const axios = require("axios");
+
+const platform = "robotstreamer";
+module.exports = [platform, async function (id, name) {
+    const {data: _data} = await axios.get(`http://api.robotstreamer.com:8080/v1/get_robot/${id}`);
+    const data = _data[0];
+
+    const live = data.status === "online";
+    const title = data.robot_name;
+    const viewers = data.viewers;
+
+    return {
+        live, name, id,
+        platform, title,
+        viewers
+    }
+}];

--- a/scrapers/trovo.js
+++ b/scrapers/trovo.js
@@ -42,7 +42,6 @@ module.exports = ["trovo", async function (username) {
         live: data.is_live,
         title: data.live_title,
         viewers: data.current_viewers,
-        id: username,
         name: username,
         avatar: data.profile_pic,
     }

--- a/scrapers/trovo.js
+++ b/scrapers/trovo.js
@@ -2,8 +2,7 @@ const axios = require("axios");
 const assert = require("assert");
 
 const id_memoization = new Map();
-const platform = "trovo";
-module.exports = [platform, async function (username) {
+module.exports = ["trovo", async function (username) {
     // TODO: Take a more functional approach and wrap the entire
     //       lambda instead of accessing it directly?
     const token = process.env.TROVO_CLIENT_ID;
@@ -43,7 +42,7 @@ module.exports = [platform, async function (username) {
         live: data.is_live,
         title: data.live_title,
         viewers: data.current_viewers,
-        id: username, platform,
+        id: username,
         name: username,
         avatar: data.profile_pic,
     }

--- a/scrapers/trovo.js
+++ b/scrapers/trovo.js
@@ -1,0 +1,50 @@
+const axios = require("axios");
+const assert = require("assert");
+
+const id_memoization = new Map();
+const platform = "trovo";
+module.exports = [platform, async function (username) {
+    // TODO: Take a more functional approach and wrap the entire
+    //       lambda instead of accessing it directly?
+    const token = process.env.TROVO_CLIENT_ID;
+    assert(!!token);
+
+    // Get IDs for usernames
+    if (!id_memoization.has(username)) {
+        const {data} = await axios.post(
+            'https://open-api.trovo.live/openplatform/getusers',
+            {user: [username]},
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'Client-ID': token,
+                }
+            }
+        );
+        id_memoization.set(username, data.users[0].channel_id);
+    }
+
+    assert(id_memoization.has(username));
+
+    const {data} = await axios.post(
+        'https://open-api.trovo.live/openplatform/channels/id',
+        {channel_id: id_memoization.get(username)},
+        {
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Client-ID': token,
+            }
+        }
+    );
+
+    return {
+        live: data.is_live,
+        title: data.live_title,
+        viewers: data.current_viewers,
+        id: username, platform,
+        name: username,
+        avatar: data.profile_pic,
+    }
+}];

--- a/scrapers/twitch.js
+++ b/scrapers/twitch.js
@@ -1,7 +1,6 @@
 const axios = require("axios");
 
 const avatars = new Map();
-const platform = "twitch";
 
 const hasAuth = process.env.TWITCH_CLIENT_ID && process.env.TWITCH_CLIENT_SECRET && 1;
 
@@ -33,7 +32,7 @@ twitch_access_token.then((data) => {
     // But you never know when it might take less
 })
 
-module.exports = [platform, async function (username) {
+module.exports = ["twitch", async function (username) {
     const access_token = (await twitch_access_token).access_token;
 
     // Update avatar every fifth scrape of the same username
@@ -63,7 +62,6 @@ module.exports = [platform, async function (username) {
         name: username,
         id: username,
         avatar: avatars.get(username)[0],
-        platform,
         title: stream_data?.title,
         viewers: stream_data?.viewer_count
     };

--- a/scrapers/twitch.js
+++ b/scrapers/twitch.js
@@ -1,0 +1,70 @@
+const axios = require("axios");
+
+const avatars = new Map();
+const platform = "twitch";
+
+const hasAuth = process.env.TWITCH_CLIENT_ID && process.env.TWITCH_CLIENT_SECRET && 1;
+
+let refreshIntervalId;
+let twitch_access_token = (hasAuth || undefined) && new Promise(async (resolve, reject) => {
+    try {
+        const {data} = await axios.post(
+            `https://id.twitch.tv/oauth2/token`
+            + `?client_id=${process.env.TWITCH_CLIENT_ID}`
+            + `&client_secret=${process.env.TWITCH_CLIENT_SECRET}`
+            + `&grant_type=client_credentials`
+        );
+        resolve(data);
+    } catch (e) {
+        reject(e);
+    }
+});
+twitch_access_token.then((data) => {
+    refreshIntervalId = setInterval(async () => {
+        const {data} = await axios.post(
+            `https://id.twitch.tv/oauth2/token`
+            + `?client_id=${process.env.TWITCH_CLIENT_ID}`
+            + `&client_secret=${process.env.TWITCH_CLIENT_SECRET}`
+            + `&grant_type=client_credentials`
+        );
+        twitch_access_token = data;
+    }, Math.min(2147483647, data.expires_in * 1000));
+    // Takes about ~2mo for a token to expire, usually.
+    // But you never know when it might take less
+})
+
+module.exports = [platform, async function (username) {
+    const access_token = (await twitch_access_token).access_token;
+
+    // Update avatar every fifth scrape of the same username
+    // or; update every avatars every 25 minutes
+    if (!avatars.has(username) || avatars.get(username)[1] === 5) {
+        const {data: user_data} = await axios.get(`https://api.twitch.tv/helix/users?login=${username}`, {
+            headers: {
+                'Client-Id': process.env.TWITCH_CLIENT_ID,
+                'Authorization': `Bearer ${access_token}`
+            },
+        });
+        avatars.set(username, [user_data.data[0].profile_image_url, 5]);
+    } else {
+        avatars.get(username)[1]--;
+    }
+
+    const {data: _data} = await axios.get(`https://api.twitch.tv/helix/streams?user_login=${username}`, {
+        headers: {
+            'Client-Id': process.env.TWITCH_CLIENT_ID,
+            'Authorization': `Bearer ${access_token}`
+        }
+    });
+    const stream_data = _data.data[0];
+
+    return {
+        live: !!stream_data,
+        name: username,
+        id: username,
+        avatar: avatars.get(username)[0],
+        platform,
+        title: stream_data?.title,
+        viewers: stream_data?.viewer_count
+    };
+}];

--- a/scrapers/twitch.js
+++ b/scrapers/twitch.js
@@ -60,7 +60,6 @@ module.exports = ["twitch", async function (username) {
     return {
         live: !!stream_data,
         name: username,
-        id: username,
         avatar: avatars.get(username)[0],
         title: stream_data?.title,
         viewers: stream_data?.viewer_count

--- a/scrapers/youtube.js
+++ b/scrapers/youtube.js
@@ -1,7 +1,6 @@
 const axios = require("axios");
 
-const platform = "youtube";
-module.exports = [platform, async function (id) {
+module.exports = ["youtube", async function (id) {
     const {data} = await axios.get(`https://youtube.com/channel/${id}`);
 
     const avatar = data.match(/channelMetadataRenderer.*?avatar.*?thumbnails.*?url".*?"(.*?)"/s)[1];
@@ -18,7 +17,7 @@ module.exports = [platform, async function (id) {
 
     let r = {
         avatar, name,
-        live, id, platform,
+        live, id,
     }
 
     // Usually, title/viewer data is sent regardless of live status.

--- a/scrapers/youtube.js
+++ b/scrapers/youtube.js
@@ -17,7 +17,7 @@ module.exports = ["youtube", async function (id) {
 
     let r = {
         avatar, name,
-        live, id,
+        live
     }
 
     // Usually, title/viewer data is sent regardless of live status.

--- a/scrapers/youtube.js
+++ b/scrapers/youtube.js
@@ -1,0 +1,33 @@
+const axios = require("axios");
+
+const platform = "youtube";
+module.exports = [platform, async function (id) {
+    const {data} = await axios.get(`https://youtube.com/channel/${id}`);
+
+    const avatar = data.match(/channelMetadataRenderer.*?avatar.*?thumbnails.*?url".*?"(.*?)"/s)[1];
+    const name = data.match(/channelMetadataRenderer.*?title".*?"(.*?)"/s)[1];
+
+    const {data: livedata} = await axios.get(`https://youtube.com/channel/${id}/live`);
+    let live, title;
+    try {
+        title = livedata.match(/videoPrimaryInfoRenderer".*?"title".*?"runs".*?"text".*?"(.*?)"/s)[1];
+        live = livedata.match(/playabilityStatus.*?status".*?"(.*?)"/s)[1] !== "LIVE_STREAM_OFFLINE";
+    } catch (e) {
+        live = false;
+    }
+
+    let r = {
+        avatar, name,
+        live, id, platform,
+    }
+
+    // Usually, title/viewer data is sent regardless of live status.
+    // However in this case it avoids some regex matches, making it slightly faster
+    if (live) {
+        r.title = title;
+        let viewers = livedata.match(/videoPrimaryInfoRenderer".*?"viewCount".*?"runs".*?"text".*?"(.*?)"/s)[1]?.split(' ')[0];
+        r.viewers = Number(viewers.replace(/[.,]/g, ""));
+    }
+
+    return r;
+}];


### PR DESCRIPTION
The daemon can now deliver data over HTTPS, provided with a key and certificate.

Also, a fairly large refactor has taken place:
- New scrapers are to be added as `.js` files to `/scrapers` that export a tuple: `[platformString, scrapeFunction]`.
- The `id` field in served objects is now guaranteed unique (given unique people input). It is calculated as the SHA-256 hash of concatenation of all entry string, i.e. `sha256("bitwavejdanks420")`
- The `platform` and `id` fields in served objects are automatically added; scrapers need not add them.
- The `viewers` and `title` fields are removed from delivered data if the stream is offline. This was only true for some platforms.